### PR TITLE
Update BayesGLM.R

### DIFF
--- a/R/BayesGLM.R
+++ b/R/BayesGLM.R
@@ -862,7 +862,8 @@ BayesGLM <- function(
   hyper_initial <- rep(list(hyper_initial), K)
   hyper_vec <- paste0(', hyper=list(theta=list(initial=', hyper_initial, '))')
 
-  formula_vec <- paste0('f(',beta_names, ', model = spde, replicate = ', repl_names, hyper_vec, ')')
+  #formula_vec <- paste0('f(',beta_names, ', model = spde, replicate = ', repl_names, hyper_vec, ')')
+  formula_vec <- paste0('f(',beta_names, ', model = "spde", replicate = ', repl_names, hyper_vec, ')')
   formula_vec <- c('y ~ -1', formula_vec)
   formula_str <- paste(formula_vec, collapse=' + ')
   formula <- as.formula(formula_str, env = globalenv())


### PR DESCRIPTION
Change the INLFA `f` model parameter `spde` to be a string, so it can be recognized as an INLA model input. [INLA `f` documentation](https://rdrr.io/github/inbo/INLA/man/f.html). Issue described in https://github.com/mandymejia/BayesfMRI/issues/17.