### PR TITLE
Address deprecation of Matrix command

### DIFF
--- a/R/EM_utils.R
+++ b/R/EM_utils.R
@@ -391,7 +391,7 @@ prep_kappa2_optim <- function(spde, mu, phi, P, vh) {
 #' @importFrom methods as
 #' @keywords internal
 create_listRcpp <- function(spde) {
-  Cmat <- as(spde$M0,"dgCMatrix")
+  Cmat <- as(as(spde$M0, "generalMatrix"), "CsparseMatrix")
   Gmat <- as((spde$M1 + Matrix::t(spde$M1)) / 2,"CsparseMatrix")
   GtCinvG <- as(spde$M2,"CsparseMatrix")
   out <- list(Cmat = Cmat,


### PR DESCRIPTION
Address deprecation of Matrix command (see warning below)

 ```
SETTING UP DATA 
 MAKING DESIGN MATRICES 
 RUNNING MODELS 

 .. LEFT CORTEX ANALYSIS 
	 848 locations removed due to NA or NaN values.
	 86 additional locations removed due to low mean.
.... prewhitening... done!

.... estimating model with EM... FINDING BEST GUESS INITIAL VALUES
as(<ddiMatrix>, "dgCMatrix") is deprecated since Matrix 1.5-0; do as(as(., "generalMatrix"), "CsparseMatrix") instead
```